### PR TITLE
Handle case where change_mode is called with no radio attached

### DIFF
--- a/wfdlogger/__main__.py
+++ b/wfdlogger/__main__.py
@@ -1326,12 +1326,13 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         if self.mode != self.mode_selector.currentText():
             self.mode = self.mode_selector.currentText()
-            if self.mode == "PH":
-                if int(self.oldfreq) < 10000000:
-                    self.cat_control.set_mode("LSB")
-                else:
-                    self.cat_control.set_mode("USB")
-            self.cat_control.set_mode(self.mode)
+            if self.cat_control:
+                if self.mode == "PH":
+                    if int(self.oldfreq) < 10000000:
+                        self.cat_control.set_mode("LSB")
+                    else:
+                        self.cat_control.set_mode("USB")
+                self.cat_control.set_mode(self.mode)
             self.send_status_udp()
 
     def changepower(self):


### PR DESCRIPTION
Prior to this change, the program aborted when changing modes without a radio attached. I added code to test if self.cat_control was valid before calling the code thaty changes the cat mode. I saw this in another few places that handled the CAT control.

#Pull Request
